### PR TITLE
feature/add-to-bottom-or-top: crash fix

### DIFF
--- a/src/Resolvers/ElementalResolver.php
+++ b/src/Resolvers/ElementalResolver.php
@@ -55,10 +55,14 @@ class ElementalResolver extends Resolver {
         $newElement->onBeforeWrite();
 
         if ($insertAtBottom) {
-            $reorderer = Injector::inst()->create(ReorderElements::class, $newElement);
-            $afterElementID = $elementalArea->Elements()->sort('Sort')->last()->ID;
-            $reorderer->reorder($afterElementID); // also writes the element
-        } else if ($afterElementID !== null) {
+            $lastElement = $elementalArea->Elements()->sort('Sort')->last();
+
+            if ($lastElement) {
+                $afterElementID = $lastElement->ID;
+            }
+        }
+
+        if ($afterElementID !== null) {
             /** @var ReorderElements $reorderer */
             $reorderer = Injector::inst()->create(ReorderElements::class, $newElement);
             $reorderer->reorder($afterElementID); // also writes the element


### PR DESCRIPTION
 insertAtBottom now sets the lastElementID preventing a crash when no elements exist on the page