### PR TITLE
Make Custom CMSFrameworks usable

### DIFF
--- a/src/CSSFramework/BootstrapCSSFramework.php
+++ b/src/CSSFramework/BootstrapCSSFramework.php
@@ -7,6 +7,8 @@ use WeDevelop\ElementalGrid\ElementalConfig;
 
 final class BootstrapCSSFramework implements CSSFrameworkInterface
 {
+    public static string $framework_key = 'bootstrap';
+
     private BaseElement $baseElement;
 
     private const COLUMN_CLASSNAME = 'col';

--- a/src/CSSFramework/BulmaCSSFramework.php
+++ b/src/CSSFramework/BulmaCSSFramework.php
@@ -7,6 +7,8 @@ use WeDevelop\ElementalGrid\ElementalConfig;
 
 final class BulmaCSSFramework implements CSSFrameworkInterface
 {
+    public static string $framework_key = 'bulma';
+
     private BaseElement $baseElement;
 
     private const COLUMN_CLASSNAME = 'column';

--- a/src/Extensions/BaseElementExtension.php
+++ b/src/Extensions/BaseElementExtension.php
@@ -2,6 +2,7 @@
 
 namespace WeDevelop\ElementalGrid\Extensions;
 
+use SilverStripe\Core\ClassInfo;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldGroup;
@@ -25,10 +26,17 @@ class BaseElementExtension extends DataExtension
     {
         parent::setOwner($owner);
 
-        match (ElementalConfig::getCSSFrameworkName()) {
-            'bulma' => $this->cssFramework = new BulmaCSSFramework($this->owner),
-            default => $this->cssFramework = new BootstrapCSSFramework($this->owner),
-        };
+        $frameworks = ClassInfo::implementorsOf(CSSFrameworkInterface::class);
+        foreach ($frameworks as $framework) {
+            if ($framework::$framework_key === ElementalConfig::getCSSFrameworkName()) {
+                $this->cssFramework = new $framework($this->owner);
+            }
+        }
+        if(!$this->cssFramework) {
+            $this->cssFramework = new BootstrapCSSFramework($this->owner);
+        }
+
+        $this->owner->extend('updateCSSFramework', $this->cssFramework);
     }
 
     public function populateDefaults(): void


### PR DESCRIPTION
Added a framework key variable for each CMSSFrameworks to identify frameworks within the setOwner function (BaseElementExtension.php). The reason for this was that even though a custom CSSFramework was set via configuration, Bootstrap was always set as the CSSFramework due to the default match. Now, using ClassInfo::implementorsOf, all existing (modules and custom) CSSFrameworks are identified and can be used.
Also added an extension hook to overwrite CSSFramework after it was set.