### PR TITLE
feat: display column title in grid editor header

### DIFF
--- a/client/src/components/ColumnBlock/ColumnBlock.scss
+++ b/client/src/components/ColumnBlock/ColumnBlock.scss
@@ -35,6 +35,13 @@
     margin-bottom: 8px;
   }
 
+  &__title {
+    margin: 0;
+    font-size: 0.7em;
+    font-weight: 600;
+    color: vars.$color-text-muted;
+  }
+
   &__badge {
     display: inline-block;
     padding: 2px 8px;

--- a/client/src/components/ColumnBlock/ColumnBlock.tsx
+++ b/client/src/components/ColumnBlock/ColumnBlock.tsx
@@ -62,6 +62,7 @@ export default function ColumnBlock({ column }: ColumnBlockProps) {
         <div className="column-block__header" data-testid="column-header">
           <DragHandle listeners={listeners} attributes={attributes} label={`Move ${column.title}`} />
           <CollapseToggle isCollapsed={isCollapsed} onToggle={toggle} label={column.title} />
+          <h4 className="column-block__title" data-testid="column-title">{column.title}</h4>
           <span className="column-block__badge" data-testid="column-badge">
             {settings.visible ? `${settings.width}/${columnCount}` : VIEWPORT_HIDDEN_LABEL}
           </span>


### PR DESCRIPTION
## Summary
- Add `<h4>` title element to the ColumnBlock header, completing the heading hierarchy (Section `<h2>` → Row `<h3>` → Column `<h4>`)
- Add corresponding SCSS styles matching the Row title pattern
- Prepares for the upcoming default title generation branch

## Test plan
- [x] All 425 JS tests pass
- [x] All 106 PHP unit tests pass
- [x] All 408 PHP integration tests pass
- [x] PHPStan analysis passes
- [ ] Visual review: column title appears in editor between collapse toggle and width badge